### PR TITLE
Adding main property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "test": "mocha --reporter=spec"
   },
+  "main": "lib/gaer.js",
   "dependencies": {
     "chalk": "^1.0.0",
     "commander": "^2.7.1",


### PR DESCRIPTION
Just installed the package via npm.

Adding the main property allows the package to be required by tools, e.g.:

```
require('gaer');
```
